### PR TITLE
Reduce the package to validation alone

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,42 +97,6 @@ spdx.exceptions.every(function(element) {
 }); // => true
 ```
 
-Comparison
-----------
-```js
-spdx.gt('GPL-3.0', 'GPL-2.0'); // => true
-spdx.lt('MPL-1.0', 'MPL-2.0'); // => true
-
-spdx.gt('LPPL-1.3a', 'LPPL-1.0'); // => true
-spdx.gt('LPPL-1.3c', 'LPPL-1.3a'); // => true
-spdx.gt('MIT', 'ISC'); // => false
-spdx.gt('OSL-1.0', 'OPL-1.0'); // => false
-spdx.gt('AGPL-3.0', 'AGPL-1.0'); // => true
-
-try {
-  spdx.gt('(MIT OR ISC)', 'GPL-3.0');
-} catch (error) {
-  error.message; // => '"(MIT OR ISC)" is not a simple license identifier'
-}
-
-spdx.satisfies('MIT', 'MIT'); // => true
-spdx.satisfies('MIT', '(ISC OR MIT)'); // => true
-spdx.satisfies('Zlib', '(ISC OR (MIT OR Zlib))'); // => true
-spdx.satisfies('GPL-3.0', '(ISC OR MIT)'); // => false
-spdx.satisfies('GPL-2.0', 'GPL-2.0+'); // => true
-spdx.satisfies('GPL-3.0', 'GPL-2.0+'); // => true
-spdx.satisfies('GPL-1.0', 'GPL-2.0+'); // => false
-
-spdx.satisfies('GPL-2.0', 'GPL-2.0+ WITH Bison-exception-2.2'); // => false
-spdx.satisfies(
-  'GPL-3.0 WITH Bison-exception-2.2', 'GPL-2.0+ WITH Bison-exception-2.2'
-); // => true
-
-spdx.satisfies('(MIT OR GPL-2.0)', '(ISC OR MIT)'); // => true
-spdx.satisfies('(MIT AND GPL-2.0)', '(MIT OR GPL-2.0)'); // => true
-spdx.satisfies('(MIT AND GPL-2.0)', '(ISC OR GPL-2.0)'); // => false
-```
-
 Version Metadata
 ----------------
 ```js

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ spdx.js
 [![license](https://img.shields.io/badge/license-Apache--2.0-303284.svg)](http://www.apache.org/licenses/LICENSE-2.0)
 [![build status](https://img.shields.io/travis/kemitchell/spdx.js.svg)](http://travis-ci.org/kemitchell/spdx.js)
 
-SPDX License Expression Syntax parser
+Parse SPDX license expressions
 
 <!--js
   // The fenced code blocks below are run as tests with `jsmd`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spdx",
-  "description": "SPDX License Expression Syntax parser",
+  "description": "parse SPDX license expressions",
   "version": "0.4.1",
   "author": "Kyle E. Mitchell <kyle@kemitchell.com> (http://kemitchell.com)",
   "bugs": "https://github.com/kemitchell/spdx.js/issues",

--- a/source/spdx.js
+++ b/source/spdx.js
@@ -2,9 +2,6 @@
 // =======
 // SPDX License Expression Syntax parser
 
-// Validation
-// ----------
-
 // Require the generated parser.
 var parser = require('./parser.generated.js').parser;
 
@@ -31,128 +28,9 @@ exports.valid = function(argument) {
   }
 };
 
-// Comparison
-// ----------
-
-var ranges = require('./ranges.json');
-
-var notALicenseIdentifier = ' is not a simple license identifier';
-
-var rangeComparison = function(comparison) {
-  return function(first, second) {
-    var firstAST = exports.parse(first);
-    if (!firstAST.hasOwnProperty('license')) {
-      throw new Error('"' + first + '"' + notALicenseIdentifier);
-    }
-    var secondAST = exports.parse(second);
-    if (!secondAST.hasOwnProperty('license')) {
-      throw new Error('"' + second + '"' + notALicenseIdentifier);
-    }
-    return ranges.some(function(range) {
-      var indexOfFirst = range.indexOf(firstAST.license);
-      if (indexOfFirst < 0) {
-        return false;
-      }
-      var indexOfSecond = range.indexOf(secondAST.license);
-      if (indexOfSecond < 0) {
-        return false;
-      }
-      return comparison(indexOfFirst, indexOfSecond);
-    });
-  };
-};
-
-exports.gt = rangeComparison(function(first, second) {
-  return first > second;
-});
-
-exports.lt = rangeComparison(function(first, second) {
-  return first < second;
-});
-
-exports.satisfies = (function() {
-  var rangesAreCompatible = function(first, second) {
-    return (
-      first.license === second.license ||
-      ranges.some(function(range) {
-        return (
-          range.indexOf(first.license) > -1 &&
-          range.indexOf(second.license)
-        );
-      })
-    );
-  };
-
-  var identifierInRange = function(identifier, range) {
-    return (
-      identifier.license === range.license ||
-      exports.gt(identifier.license, range.license)
-    );
-  };
-
-  var licensesAreCompatible = function(first, second) {
-    if (first.exception !== second.exception) {
-      return false;
-    } else if (second.hasOwnProperty('license')) {
-      if (second.hasOwnProperty('plus')) {
-        if (first.hasOwnProperty('plus')) {
-          // first+, second+
-          return rangesAreCompatible(first, second);
-        } else {
-          // first, second+
-          return identifierInRange(first, second);
-        }
-      } else {
-        if (first.hasOwnProperty('plus')) {
-          // first+, second
-          return identifierInRange(second, first);
-        } else {
-          // first, second
-          return first.license === second.license;
-        }
-      }
-    }
-  };
-
-  var recurseLeftAndRight = function(first, second) {
-    var firstConjunction = first.conjunction;
-    if (firstConjunction === 'and') {
-      return (
-        recurse(first.left, second) &&
-        recurse(first.right, second)
-      );
-    } else if (firstConjunction === 'or') {
-      return (
-        recurse(first.left, second) ||
-        recurse(first.right, second)
-      );
-    }
-  };
-
-  var recurse = function(first, second) {
-    if (first.hasOwnProperty('conjunction')) {
-      return recurseLeftAndRight(first, second);
-    } else if (second.hasOwnProperty('conjunction')) {
-      return recurseLeftAndRight(second, first);
-    } else {
-      return licensesAreCompatible(first, second);
-    }
-  };
-
-  return function(first, second) {
-    return recurse(parser.parse(first), parser.parse(second));
-  };
-})();
-
-// Reference Data
-// --------------
-
 // Require the same license and exception data used by the parser.
 exports.licenses = require('spdx-license-ids');
 exports.exceptions = require('./exceptions.json');
-
-// Version Metadata
-// ----------------
 
 // The License Expression Syntax version
 exports.specificationVersion = '2.0';

--- a/source/spdx.js
+++ b/source/spdx.js
@@ -1,8 +1,3 @@
-// spdx.js
-// =======
-// SPDX License Expression Syntax parser
-
-// Require the generated parser.
 var parser = require('./parser.generated.js').parser;
 
 exports.parse = function(argument) {


### PR DESCRIPTION
This pull request removes license expression comparison (`gt` and friends), as well as the experimental `satisfies` algorithm, from `spdx`. Those functions have been split off into `spdx-compare` and `spdx-satisfies`, respectively.

@othiym23, I'm particularly interested to know if this seems alright to you. With respect to `npm`, the idea would be to publish a leaner, meaner `spdx` as `0.5.0`, then update `validate-npm-package-license` and friends. Since `npm` is really only in it for `parse` and `valid`, the net effect will probably be more free disk space. No semantic changes in active code paths.

My overall goal is still a play on `node-semver`. I'd just prefer to do that in smaller modules, so I can play a little faster and looser with with the code directed more at audit and analysis.
